### PR TITLE
[BUGFIX] Two fixes to the evaluation code, and one to augmentation loader

### DIFF
--- a/augmentloader.py
+++ b/augmentloader.py
@@ -61,9 +61,9 @@ class AugmentLoader:
             num_img = self.batch_size // self.num_aug
             return _Iter(self, sampler, num_img, self.num_aug)
         elif self.sampler == "random":
-            size = len(self.dataset.targets) // self.batch_size * self.batch_size
-            sampler = RandomSampler(self.dataset, size, shuffle=self.shuffle)
             num_img = self.batch_size // self.num_aug
+            size = len(self.dataset.targets) // num_img * num_img
+            sampler = RandomSampler(self.dataset, size, shuffle=self.shuffle)
             return _Iter(self, sampler, num_img, self.num_aug)
         else:
             raise NameError(f"sampler {self.sampler} not found.")

--- a/cluster.py
+++ b/cluster.py
@@ -13,6 +13,7 @@ from sklearn.linear_model import orthogonal_mp
 from sklearn.neighbors import kneighbors_graph
 from sklearn.preprocessing import normalize
 from sklearn.utils import check_random_state, check_array, check_symmetric
+from utils import clustering_accuracy
 
 
 class SelfRepresentation(BaseEstimator, ClusterMixin):
@@ -571,44 +572,6 @@ class LeastSquaresSubspaceClustering(SelfRepresentation):
     
     def _self_representation(self, X):
         self.representation_matrix_ = least_squares_subspace_clustering(X, self.gamma, self.exclude_self)
-
-
-def clustering_accuracy(labels_true, labels_pred):
-    """Clustering Accuracy between two clusterings.
-    Clustering Accuracy is a measure of the similarity between two labels of
-    the same data. Assume that both labels_true and labels_pred contain n 
-    distinct labels. Clustering Accuracy is the maximum accuracy over all
-    possible permutations of the labels, i.e.
-    \max_{\sigma} \sum_i labels_true[i] == \sigma(labels_pred[i])
-    where \sigma is a mapping from the set of unique labels of labels_pred to
-    the set of unique labels of labels_true. Clustering accuracy is one if 
-    and only if there is a permutation of the labels such that there is an
-    exact match
-    This metric is independent of the absolute values of the labels:
-    a permutation of the class or cluster label values won't change the
-    score value in any way.
-    This metric is furthermore symmetric: switching ``label_true`` with
-    ``label_pred`` will return the same score value. This can be useful to
-    measure the agreement of two independent label assignments strategies
-    on the same dataset when the real ground truth is not known.
-    
-    Parameters
-    ----------
-    labels_true : int array, shape = [n_samples]
-    	A clustering of the data into disjoint subsets.
-    labels_pred : array, shape = [n_samples]
-    	A clustering of the data into disjoint subsets.
-    
-    Returns
-    -------
-    accuracy : float
-       return clustering accuracy in the range of [0, 1]
-    """
-    labels_true, labels_pred = supervised.check_clusterings(labels_true, labels_pred)
-    # value = supervised.contingency_matrix(labels_true, labels_pred, sparse=False)
-    value = supervised.contingency_matrix(labels_true, labels_pred)
-    [r, c] = linear_sum_assignment(-value)
-    return value[r, c].sum() / len(labels_true)
 
 
 def kmeans(args, train_features, train_labels, test_features=None, test_labels=None):

--- a/train_func.py
+++ b/train_func.py
@@ -9,7 +9,7 @@ import torchvision
 import torchvision.transforms as transforms
 from torch.utils.data import DataLoader
 
-from cluster import ElasticNetSubspaceClustering, clustering_accuracy
+from cluster import ElasticNetSubspaceClustering
 import utils
 
 

--- a/train_func.py
+++ b/train_func.py
@@ -139,6 +139,15 @@ def load_transforms(name):
             transforms.RandomApply([transforms.ColorJitter(0.4, 0.4, 0.4, 0.1)], p=0.8),
             transforms.RandomGrayscale(p=0.2),
             transforms.ToTensor()])
+    elif _name == "cifar_norm":
+        transform = transforms.Compose([
+            transforms.RandomResizedCrop(32),
+            transforms.RandomHorizontalFlip(p=0.5),
+            transforms.RandomApply([transforms.ColorJitter(0.4, 0.4, 0.4, 0.1)], p=0.8),
+            transforms.RandomGrayscale(p=0.2),
+            transforms.ToTensor(),
+            transforms.Normalize((0.4914, 0.4822, 0.4465), (0.2023, 0.1994, 0.2010))
+        ])
     elif _name == "mnist":
          transform = transforms.Compose([
             transforms.RandomChoice([

--- a/utils.py
+++ b/utils.py
@@ -97,9 +97,9 @@ def compute_accuracy(y_pred, y_true):
 
 def clustering_accuracy(labels_true, labels_pred):
     """Compute clustering accuracy."""
-    from sklearn.metrics.cluster import supervised
+    from sklearn.metrics.cluster import _supervised
     from scipy.optimize import linear_sum_assignment
-    labels_true, labels_pred = supervised.check_clusterings(labels_true, labels_pred)
-    value = supervised.contingency_matrix(labels_true, labels_pred)
+    labels_true, labels_pred = _supervised.check_clusterings(labels_true, labels_pred)
+    value = _supervised.contingency_matrix(labels_true, labels_pred)
     [r, c] = linear_sum_assignment(-value)
     return value[r, c].sum() / len(labels_true)


### PR DESCRIPTION
- Fix a bug in 'utils.py' that imports 'supervised' instead of '_supervised' from sklearn.metrics.cluster, due to a recent non-backward-compatible change in sklearn library.
- Removed the "clustering_accuracy" function in cluster.py, which is 1) not functional and causing error 2) duplicate of what is already existing in utils.py.
- Fixed a bug in the random sampler of augmentation loader that causes the number of original samples loaded to be unexpectedly smaller.